### PR TITLE
Fixed a bug that caused the 1.8 client crash

### DIFF
--- a/src/main/kotlin/me/rerere/virtualtag/listener/PlayerListener.kt
+++ b/src/main/kotlin/me/rerere/virtualtag/listener/PlayerListener.kt
@@ -2,19 +2,20 @@ package me.rerere.virtualtag.listener
 
 import me.rerere.virtualtag.virtualTag
 import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
 import org.bukkit.event.player.PlayerQuitEvent
 
 class PlayerListener : Listener {
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST)
     fun onJoin(event: PlayerJoinEvent) {
         val player = event.player
         virtualTag().tagHandler.sendCurrentNameTags(player)
         virtualTag().tagManager.updatePlayerTag(player)
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST)
     fun onQuit(event: PlayerQuitEvent){
         virtualTag().tagManager.playerQuit(event.player)
         virtualTag().tagHandler.removePlayerTag(event.player)

--- a/src/main/kotlin/me/rerere/virtualtag/tag/team/impl/TeamPacketSenderImpl8.kt
+++ b/src/main/kotlin/me/rerere/virtualtag/tag/team/impl/TeamPacketSenderImpl8.kt
@@ -13,11 +13,14 @@ class TeamPacketSenderImpl8 : TeamPacketSender {
     override fun createTeam(virtualTeam: VirtualTeam) {
         with(virtualTeam) {
             createPacket(PacketType.Play.Server.SCOREBOARD_TEAM) {
-                // team mode
                 integers.apply {
-                    writeSafely(0,  lastChatColor(prefix).ordinal)
-                    writeSafely(1, 0)
-                    writeSafely(2, 0)
+                    // the RESET color index in 1.8 client is -1
+                    // but the lastChatColor function will return 21 index, on 1.8 client the max index is 15
+                    // this will make client NullPointerException and crash
+                    // so just check if the index > 15, if so, set it to -1
+                    writeSafely(0, if (lastChatColor(prefix).ordinal > 15) -1 else lastChatColor(prefix).ordinal) // color
+                    writeSafely(1, 0) // action - 0 = create team and add players
+                    writeSafely(2, 0) // friendlyFlags
                 }
 
                 // players
@@ -38,11 +41,10 @@ class TeamPacketSenderImpl8 : TeamPacketSender {
     override fun createForPlayer(virtualTeam: VirtualTeam, player: Player) {
         with(virtualTeam){
             createPacket(PacketType.Play.Server.SCOREBOARD_TEAM) {
-                // team mode
                 integers.apply {
-                    writeSafely(0,  lastChatColor(prefix).ordinal)
-                    writeSafely(1, 0)
-                    writeSafely(2, 0)
+                    writeSafely(0, if (lastChatColor(prefix).ordinal > 15) -1 else lastChatColor(prefix).ordinal) // color
+                    writeSafely(1, 0) // action - 0 = create team and add players
+                    writeSafely(2, 0) // friendlyFlags
                 }
 
                 // players
@@ -64,7 +66,7 @@ class TeamPacketSenderImpl8 : TeamPacketSender {
         with(virtualTeam){
             createPacket(PacketType.Play.Server.SCOREBOARD_TEAM) {
                 strings.writeSafely(0, name)
-                integers.writeSafely(1, 1) // mode
+                integers.writeSafely(1, 1) // action - 1 = remove team
 
                 // default packet data
                 strings.writeSafely(4, "always")
@@ -84,9 +86,9 @@ class TeamPacketSenderImpl8 : TeamPacketSender {
                 }
 
                 integers.apply {
-                    integers.writeSafely(1, 3) // mode
                     writeSafely(0, -1) // color
-                    writeSafely(2, 0) // packData
+                    writeSafely(1, 3) // action - 3 = add player(s)
+                    writeSafely(2, 0) // friendlyFlags
                 }
 
                 getSpecificModifier(Collection::class.java).writeSafely(0, entities.toMutableList())
@@ -103,9 +105,9 @@ class TeamPacketSenderImpl8 : TeamPacketSender {
                 }
 
                 integers.apply {
-                    integers.writeSafely(1, 4) // mode
                     writeSafely(0, -1) // color
-                    writeSafely(2, 0) // packData
+                    writeSafely(1, 4) // action - 4 = remove player(s)
+                    writeSafely(2, 0) // friendlyFlags
                 }
 
                 getSpecificModifier(Collection::class.java).writeSafely(0, entities.toMutableList())


### PR DESCRIPTION
This issue fixes a 1.8 client crash caused by illegal packets

### Some meaningless analysis:
In the 1.8 client, the format index for RESET format is -1
```java
RESET("RESET", 'r', -1);
```

But the `lastChatColor(String prefix)` will return 21 when passed a RESET format code

When a client tries to process an exception color value from the server
```java
        if (packetIn.getAction() == 0 || packetIn.getAction() == 2)
        {
            scoreplayerteam.setTeamName(packetIn.getDisplayName());
            scoreplayerteam.setNamePrefix(packetIn.getPrefix());
            scoreplayerteam.setNameSuffix(packetIn.getSuffix());
            scoreplayerteam.setChatFormat(EnumChatFormatting.func_175744_a(packetIn.getColor()));
            scoreplayerteam.func_98298_a(packetIn.getFriendlyFlags());
            Team.EnumVisible team$enumvisible = Team.EnumVisible.func_178824_a(packetIn.getNameTagVisibility());

            if (team$enumvisible != null)
            {
                scoreplayerteam.setNameTagVisibility(team$enumvisible);
            }
        }
```
The `func_175744_a` will return null because the index can't find the format code
```java
    public static EnumChatFormatting func_175744_a(int p_175744_0_)
    {
        if (p_175744_0_ < 0)
        {
            return RESET;
        }
        else
        {
            for (EnumChatFormatting enumchatformatting : values())
            {
                if (enumchatformatting.getColorIndex() == p_175744_0_)
                {
                    return enumchatformatting;
                }
            }

            return null; < just return null
        }
    }
```
The client will crash immediately with a NullPointerException
```log
[Client thread/FATAL]: Unreported exception thrown!
java.lang.NullPointerException
	at net.minecraft.client.gui.GuiIngame.renderGameOverlay(GuiIngame.java:332) ~[bin/:?]
	at net.minecraft.client.renderer.EntityRenderer.updateCameraAndRender(EntityRenderer.java:1387) ~[bin/:?]
	at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1163) ~[bin/:?]
	at net.minecraft.client.Minecraft.run(Minecraft.java:425) [bin/:?]
	at net.minecraft.client.main.Main.main(Main.java:121) [bin/:?]
	at Start.main(Start.java:9) [bin/:?]
```
